### PR TITLE
Fix deprecation message in chrome

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,9 @@ var blacklistedKeys = {
 	$console: true,
 	$parent: true,
 	$self: true,
-	$frames: true
+	$frames: true,
+	$webkitStorageInfo: true,
+	$webkitIndexedDB: true
 };
 var hasAutomationEqualityBug = (function () {
 	/* global window */

--- a/test/shim.js
+++ b/test/shim.js
@@ -202,7 +202,7 @@ test('shadowed properties', function (t) {
 
 test('host objects constructor.prototype equal to themselves', { skip: typeof window === 'undefined' }, function (t) {
 	var keys, exception;
-	var blacklistedKeys = ['window', 'console', 'parent', 'self', 'frames'];
+	var blacklistedKeys = ['window', 'console', 'parent', 'self', 'frames', 'webkitStorageInfo', 'webkitIndexedDB'];
 	for (var k in window) {
 		keys = exception = void 0;
 		if (indexOf(blacklistedKeys, k) === -1 && has.call(window, k) && window[k] !== null && typeof window[k] === 'object') {


### PR DESCRIPTION
Without this key blacklisted chrome shows this warnings in console:
'window.webkitStorageInfo' is deprecated. Please use 'navigator.webkitTemporaryStorage' or 'navigator.webkitPersistentStorage' instead.
'webkitIndexedDB' is deprecated. Please use 'indexedDB' instead.