### PR TITLE
[Fix] exclude keys regarding the style (eg. `pageYOffset`) on `window…

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,12 +27,20 @@ var excludedKeys = {
 	$frame: true,
 	$frameElement: true,
 	$frames: true,
-	$height: true,
+	$innerHeight: true,
+	$innerWidth: true,
+	$outerHeight: true,
+	$outerWidth: true,
+	$pageXOffset: true,
+	$pageYOffset: true,
 	$parent: true,
+	$scrollLeft: true,
+	$scrollTop: true,
+	$scrollX: true,
+	$scrollY: true,
 	$self: true,
 	$webkitIndexedDB: true,
 	$webkitStorageInfo: true,
-	$width: true,
 	$window: true
 };
 var hasAutomationEqualityBug = (function () {

--- a/test/shim.js
+++ b/test/shim.js
@@ -210,12 +210,20 @@ test('host objects on `window` constructor.prototype equal to themselves', { ski
 		$frame: true,
 		$frameElement: true,
 		$frames: true,
-		$height: true,
+		$innerHeight: true,
+		$innerWidth: true,
+		$outerHeight: true,
+		$outerWidth: true,
+		$pageXOffset: true,
+		$pageYOffset: true,
 		$parent: true,
+		$scrollLeft: true,
+		$scrollTop: true,
+		$scrollX: true,
+		$scrollY: true,
 		$self: true,
 		$webkitIndexedDB: true,
 		$webkitStorageInfo: true,
-		$width: true,
 		$window: true
 	};
 	for (var k in window) {


### PR DESCRIPTION
There are other keys wich force a reflow. I think the ones added in the pull request should be all. Checked this at least with the timeline feature of chrome. After my change there is no further reflow.

For the added attributes look at https://gist.github.com/paulirish/5d52fb081b3570c81e3a which mentions the pageYOffset and pageXOffset in the comments. 

Sorry that my issue [#31] wasn't as precise as neccessary.