### PR TITLE
Preventing chrome app error messages

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,7 +43,16 @@ var excludedKeys = {
 	$webkitStorageInfo: true,
 	$window: true
 };
+var isChromeExtension = (function () {
+	/* global chrome */
+	return (typeof chrome !== 'undefined') &&
+		(typeof chrome.runtime !== 'undefined') &&
+		(typeof chrome.runtime.id !== 'undefined');
+}());
 var hasAutomationEqualityBug = (function () {
+	if (isChromeExtension) {
+		return false;
+	}
 	/* global window */
 	if (typeof window === 'undefined') { return false; }
 	for (var k in window) {


### PR DESCRIPTION
Chrome app doesn't have the automation equality bug (at least in reasonably new releases I just tried). 

That fixes the issue https://github.com/ljharb/object-keys/issues/34
