### PR TITLE
Exclude deprecated Firefox keys

### DIFF
--- a/implementation.js
+++ b/implementation.js
@@ -31,6 +31,8 @@ if (!Object.keys) {
 		$frames: true,
 		$innerHeight: true,
 		$innerWidth: true,
+		$onmozfullscreenchange: true,
+		$onmozfullscreenerror: true,
 		$outerHeight: true,
 		$outerWidth: true,
 		$pageXOffset: true,

--- a/test/shim.js
+++ b/test/shim.js
@@ -230,6 +230,8 @@ test('host objects on `window` constructor.prototype equal to themselves', { ski
 		$frames: true,
 		$innerHeight: true,
 		$innerWidth: true,
+		$onmozfullscreenchange: true,
+		$onmozfullscreenerror: true,
 		$outerHeight: true,
 		$outerWidth: true,
 		$pageXOffset: true,


### PR DESCRIPTION
Similar to #46, exclude keys that generate deprecation warnings in Firefox.